### PR TITLE
Implement __getitem__ on RPCProxy

### DIFF
--- a/test/roles/test_callers.py
+++ b/test/roles/test_callers.py
@@ -88,3 +88,11 @@ def test_call_with_no_args_but_a_kwarg(hello_service, router):
         response = caller.rpc.say_greeting("Simon", greeting="goodbye")
 
     assert response == "goodbye to Simon"
+
+
+def test_call_with_getitem_and_args_and_kwargs(hello_service, router):
+    caller = Client(router=router)
+    with caller:
+        response = caller.rpc['say_greeting']("Simon", greeting="goodbye")
+
+    assert response == "goodbye to Simon"

--- a/wampy/roles/caller.py
+++ b/wampy/roles/caller.py
@@ -54,6 +54,10 @@ class RpcProxy:
     def __init__(self, client):
         self.client = client
 
+
+    def __getitem__(self, name):
+        return self.__getattr__(name)
+
     def __getattr__(self, name):
 
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
This lets me call "crossbar style" defined procedures easily from the RPC api.

For example:
```
client.rpc['com.example.foobar'](*args, **kwargs)
```