### PR TITLE
Downgrade eventlet to resolve crash.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     keywords='WAMP RPC',
     packages=find_packages(),
     install_requires=[
-        "eventlet==0.21.0",
+        "eventlet==0.20.1",
         "six==1.10.0",
     ],
     extras_require={


### PR DESCRIPTION
This means that the tests should pass on Python 2.7. The combination of 2.7.13 (now used by Travis-CI) and eventlet 0.21.0 (latest) seems to cause the bug at https://github.com/eventlet/eventlet/issues/401