### PR TITLE
replace eventlet with gevent

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,14 +37,9 @@ setup(
     install_requires=[
         "six==1.10.0",
         "simplejson==3.11.1",
+        "gevent>=1.1"
     ],
     extras_require={
-        ':python_version == "2.7"': [
-            "eventlet<0.21.0",
-        ],
-        ':python_version >= "3"': [
-            "eventlet>=0.21.0",
-        ],
         'dev': [
             "crossbar==0.15.0",
             "autobahn==0.17.2",

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -2,13 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import eventlet
+import gevent
 
 
 def assert_stops_raising(
         fn, exception_type=Exception, timeout=5, interval=0.1):
 
-    with eventlet.Timeout(timeout):
+    with gevent.Timeout(timeout):
         while True:
             try:
                 fn()
@@ -16,4 +16,4 @@ def assert_stops_raising(
                 pass
             else:
                 return
-            eventlet.sleep(interval)
+            gevent.sleep(interval)

--- a/wampy/__init__.py
+++ b/wampy/__init__.py
@@ -5,7 +5,7 @@
 # Set default logging handler to avoid "No handler found" warnings.
 import logging
 
-import eventlet
+import gevent.monkey
 
 
 try:  # Python 2.7+
@@ -21,5 +21,5 @@ from wampy.peers.clients import Client  # noqa
 root = logging.getLogger(__name__)
 root.addHandler(NullHandler())
 
-root.warning('eventlet about to monkey patched your environment')
-eventlet.monkey_patch()
+root.warning('gevent about to monkey patched your environment')
+gevent.monkey.patch_all()

--- a/wampy/testing/helpers.py
+++ b/wampy/testing/helpers.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import eventlet
+import gevent
 
 from wampy.message_handler import MessageHandler
 
@@ -10,36 +10,36 @@ TIMEOUT = 5
 
 
 def wait_for_subscriptions(client, number_of_subscriptions):
-    with eventlet.Timeout(TIMEOUT):
+    with gevent.Timeout(TIMEOUT):
         while (
             len(client.session.subscription_map.keys())
             < number_of_subscriptions
         ):
-            eventlet.sleep()
+            gevent.sleep(0.01)
 
 
 def wait_for_registrations(client, number_of_registrations):
-    with eventlet.Timeout(TIMEOUT):
+    with gevent.Timeout(TIMEOUT):
         while (
             len(client.session.registration_map.keys())
             < number_of_registrations
         ):
-            eventlet.sleep()
+            gevent.sleep(0.01)
 
 
 def wait_for_session(client):
-    with eventlet.Timeout(TIMEOUT):
+    with gevent.Timeout(TIMEOUT):
         while client.session.id is None:
-            eventlet.sleep()
+            gevent.sleep(0.01)
 
 
 def wait_for_messages(client, number_of_messages):
     messages_received = (
         client.session.message_handler.messages_received)
 
-    with eventlet.Timeout(TIMEOUT):
+    with gevent.Timeout(TIMEOUT):
         while len(messages_received) < number_of_messages:
-            eventlet.sleep()
+            gevent.sleep(0.01)
 
     return messages_received
 

--- a/wampy/transports/websocket/connection.py
+++ b/wampy/transports/websocket/connection.py
@@ -9,7 +9,7 @@ import uuid
 from base64 import encodestring
 from socket import error as socket_error
 
-import eventlet
+import gevent
 
 from wampy.constants import WEBSOCKET_SUBPROTOCOLS, WEBSOCKET_VERSION
 from wampy.errors import (
@@ -69,7 +69,7 @@ class WebSocket(Transport, ParseUrlMixin):
 
             try:
                 bytes = self.socket.recv(bufsize)
-            except eventlet.greenlet.GreenletExit as exc:
+            except gevent.greenlet.GreenletExit as exc:
                 raise ConnectionError('Connection closed: "{}"'.format(exc))
             except socket.timeout as e:
                 message = str(e)
@@ -150,9 +150,9 @@ class WebSocket(Transport, ParseUrlMixin):
         self.socket.send(handshake.encode())
 
         try:
-            with eventlet.Timeout(5):
+            with gevent.Timeout(5):
                 self.status, self.headers = self._read_handshake_response()
-        except eventlet.Timeout:
+        except gevent.Timeout:
             raise WampyError(
                 'No response after handshake "{}"'.format(handshake)
             )
@@ -208,7 +208,7 @@ class WebSocket(Transport, ParseUrlMixin):
         while True:
             # we need this to guarantee we can context switch back to the
             # Timeout.
-            eventlet.sleep()
+            gevent.sleep(0.01)
 
             received_bytes = read_line()
             if received_bytes == b'\r\n':


### PR DESCRIPTION
I would love to be able to use `wampy` within my `gevent`-based application, but I'm pretty sure the use of `eventlet` precludes that.  I've never used `eventlet` so I can't speak to the technical differences between the two libraries, but `gevent` is *very* widely adopted at this point and `eventlet` is not.  Would you accept a PR that ports this project to `gevent`?   All the tests are passing.

