### PR TITLE
Fix for AttributeError: 'NoneType' object has no attribute 'shutdown'

### DIFF
--- a/wampy/transports/websocket/connection.py
+++ b/wampy/transports/websocket/connection.py
@@ -46,12 +46,13 @@ class WebSocket(Transport, ParseUrlMixin):
         return self
 
     def disconnect(self):
-        try:
-            self.socket.shutdown(socket.SHUT_RDWR)
-        except socket.error:
-            pass
+        if self.socket:
+            try:
+                self.socket.shutdown(socket.SHUT_RDWR)
+            except socket.error:
+                pass
 
-        self.socket.close()
+            self.socket.close()
 
     def send(self, message):
         frame = Text(payload=json_serialize(message))


### PR DESCRIPTION
In unittests I get this error:

```
    def disconnect(self):
        try:
>           self.socket.shutdown(socket.SHUT_RDWR)
E           AttributeError: 'NoneType' object has no attribute 'shutdown'

../../../.virtualenvs/packy-agent2-eBU3dgqa/lib/python3.7/site-packages/wampy/transports/websocket/connection.py:49: AttributeError
```

It seems that disconnect happens before connection established. It could be rare situation in production, but still requires a fix for such cases mine or there may be other case even in production.

I am not sure if this pull request is good enough (maybe a more sophisticated fix is required) otherwise consider it as a bug report.