### PR TITLE
Relax six dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "eventlet==0.20.1",
-        "six==1.10.0",
+        "six>=1.10.0",
         "simplejson==3.11.1",
         "gevent>1.1",  # fixes infinite SSL recursion bug
     ],


### PR DESCRIPTION
Otherwise I cannot use six v1.11.0. Please, consider relaxing other dependencies, because for libraries it recommended to use relaxed dependencies to stay compatible with each other (when you use them in the same project).

When you use a tool that formally checks dependencies compatibility like `pipenv` it becomes impossible to just install new version of `six`, because the tool gives an error. Example:
`pipenv.exceptions.ResolutionFailure: ERROR: ERROR: Could not find a version that matches six==1.10.0,>=1.11.0,>=1.4.0,>=1.5`

Notice that libraries use `>=`.