### PR TITLE
Expose WAMP/Session timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,16 +36,14 @@ setup(
     install_requires=[
         "attrs>=17.4.0 ",
         "eventlet==0.20.1",
-        "six==1.10.0",
+        "six==1.11.0",
         "simplejson==3.11.1",
         "gevent>1.1",  # fixes infinite SSL recursion bug
     ],
     extras_require={
         'dev': [
-            "crossbar==0.15.0",
-            "autobahn==0.17.2",
-            "Twisted==17.9.0",
-            "pytest==3.1.3",
+            "crossbar==18.4.1",
+            "pytest==3.6.0",
             "mock==1.3.0",
             "pytest-capturelog==0.7",
             "colorlog",

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,8 @@ setup(
     extras_require={
         'dev': [
             "crossbar==18.4.1",
-            "pytest==3.6.0",
+            "pytest==4.0.2",
             "mock==1.3.0",
-            "pytest-capturelog==0.7",
             "colorlog",
             "flake8==3.5.0",
             "gevent-websocket==0.10.1",

--- a/test/roles/test_callers.py
+++ b/test/roles/test_callers.py
@@ -130,9 +130,10 @@ class TestClientRpc:
 
 class TestCallerTimeout:
     @pytest.mark.parametrize("call_timeout, wait, reward", [
-        (1000, 2, None),
-        (2000, 1, "$$$$"),
-        (900, 1.1, None),
+        (1, 2, None),
+        (2, 1, "$$$$"),
+        (0.9, 1.1, None),
+        (1, 3, None),
     ])
     def test_timeout_values(
         self, call_timeout, wait, reward, router, really_slow_service,

--- a/test/roles/test_callers.py
+++ b/test/roles/test_callers.py
@@ -47,7 +47,6 @@ class ReallySlowService(Client):
 
     @callee
     def requires_patience(self, wait_in_seconds):
-        print('waiting for %s seconds' % wait_in_seconds)
         async_ = get_async_adapter()
         async_.sleep(wait_in_seconds)
         reward_for_waiting = "$$$$"

--- a/test/roles/test_callers.py
+++ b/test/roles/test_callers.py
@@ -48,7 +48,7 @@ class BinaryNumberService(Client):
 class ReallySlowService(Client):
 
     @callee
-    def requiers_patience(self, wait_in_seconds):
+    def requires_patience(self, wait_in_seconds):
         async = get_async_adapter()
         async.sleep(wait_in_seconds)
         reward_for_waiting = "$$$$"
@@ -135,7 +135,7 @@ class TestCallerTimeout:
     def test_timeout_values(self, router, really_slow_service):
         with Client(router=router, call_timeout=1) as client:
             try:
-                resp = client.rpc.requiers_patience(wait_in_seconds=2)
+                resp = client.rpc.requires_patience(wait_in_seconds=2)
             except WampyTimeOutError:
                 resp = None
 

--- a/test/roles/test_callers.py
+++ b/test/roles/test_callers.py
@@ -8,7 +8,7 @@ from datetime import date
 import pytest
 
 from wampy.backends import get_async_adapter
-from wampy.errors import WampProtocolError
+from wampy.errors import WampyTimeOutError
 from wampy.peers.clients import Client
 from wampy.roles.callee import callee
 from wampy.testing import wait_for_registrations
@@ -137,7 +137,8 @@ class TestCallerTimeout:
         with Client(router=router, call_timeout=1) as client:
             try:
                 resp = client.rpc.requiers_patience(wait_in_seconds=2)
-            except WampProtocolError:
+            except WampyTimeOutError:
+                # this should be a WampyTimeOutError
                 pass
 
         assert resp is None

--- a/test/roles/test_callers.py
+++ b/test/roles/test_callers.py
@@ -8,6 +8,7 @@ from datetime import date
 import pytest
 
 from wampy.backends import get_async_adapter
+from wampy.errors import WampProtocolError
 from wampy.peers.clients import Client
 from wampy.roles.callee import callee
 from wampy.testing import wait_for_registrations
@@ -134,6 +135,9 @@ class TestCallerTimeout:
     def test_timeout_values(self, router, really_slow_service):
         resp = None
         with Client(router=router, call_timeout=1) as client:
-            resp = client.rpc.requiers_patience(wait_in_seconds=2)
+            try:
+                resp = client.rpc.requiers_patience(wait_in_seconds=2)
+            except WampProtocolError:
+                pass
 
         assert resp is None

--- a/test/roles/test_callers.py
+++ b/test/roles/test_callers.py
@@ -133,12 +133,10 @@ class TestClientRpc:
 class TestCallerTimeout:
 
     def test_timeout_values(self, router, really_slow_service):
-        resp = None
         with Client(router=router, call_timeout=1) as client:
             try:
                 resp = client.rpc.requiers_patience(wait_in_seconds=2)
             except WampyTimeOutError:
-                # this should be a WampyTimeOutError
-                pass
+                resp = None
 
         assert resp is None

--- a/wampy/backends/eventlet_.py
+++ b/wampy/backends/eventlet_.py
@@ -4,7 +4,7 @@
 
 import eventlet
 
-from wampy.errors import WampProtocolError
+from wampy.errors import WampyTimeOutError
 from wampy.interfaces import Async
 
 
@@ -20,7 +20,7 @@ class Eventlet(Async):
         try:
             message = self._wait_for_message(timeout)
         except eventlet.Timeout:
-            raise WampProtocolError(
+            raise WampyTimeOutError(
                 "no message returned (timed-out in {})".format(timeout)
             )
         return message

--- a/wampy/backends/gevent_.py
+++ b/wampy/backends/gevent_.py
@@ -20,8 +20,8 @@ class Gevent(Async):
 
     def receive_message(self, timeout):
         try:
-            message = self.message_queue.get(timeout=timeout)
-        except gevent.queue.Empty:
+            message = self._wait_for_message(timeout)
+        except gevent.Timeout:
             raise WampyTimeOutError(
                 "no message returned (timed-out in {})".format(timeout)
             )
@@ -33,3 +33,13 @@ class Gevent(Async):
 
     def sleep(self, time):
         return gevent.sleep(time)
+
+    def _wait_for_message(self, timeout):
+        q = self.message_queue
+
+        with gevent.Timeout(timeout):
+            while q.qsize() == 0:
+                gevent.sleep()
+
+        message = q.get()
+        return message

--- a/wampy/backends/gevent_.py
+++ b/wampy/backends/gevent_.py
@@ -6,7 +6,7 @@ import gevent
 import gevent.queue
 import gevent.monkey
 
-from wampy.errors import WampProtocolError
+from wampy.errors import WampyTimeOutError
 from wampy.interfaces import Async
 
 
@@ -22,7 +22,7 @@ class Gevent(Async):
         try:
             message = self.message_queue.get(timeout=timeout)
         except gevent.queue.Empty:
-            raise WampProtocolError(
+            raise WampyTimeOutError(
                 "no message returned (timed-out in {})".format(timeout)
             )
         return message

--- a/wampy/constants.py
+++ b/wampy/constants.py
@@ -39,7 +39,7 @@ DEFAULT_ROLES = {
     },
     'authmethods': ['anonymous']
 }
-DEFAULT_TIMEOUT = 10000  # milliseconds
+DEFAULT_TIMEOUT = 10  # milliseconds
 
 SUBSCRIBER = "subscriber"
 

--- a/wampy/constants.py
+++ b/wampy/constants.py
@@ -39,7 +39,7 @@ DEFAULT_ROLES = {
     },
     'authmethods': ['anonymous']
 }
-DEFAULT_TIMEOUT = 10  # seconds
+DEFAULT_TIMEOUT = 10000  # milliseconds
 
 SUBSCRIBER = "subscriber"
 

--- a/wampy/constants.py
+++ b/wampy/constants.py
@@ -21,6 +21,9 @@ ROLES = [
 
 # Basic Profile
 DEFAULT_REALM = "realm1"
+# TODO: this encapsulates more than just "roles", while "features"
+# should really be passed in here too, e.g. `call_timeout`. This was
+# not fully understood when first desigining the API.
 DEFAULT_ROLES = {
     'roles': {
         'subscriber': {},
@@ -28,10 +31,15 @@ DEFAULT_ROLES = {
         'callee': {
             'shared_registration': True,
         },
-        'caller': {},
+        'caller': {
+            'features': {
+                'call_timeout': True,
+            }
+        },
     },
     'authmethods': ['anonymous']
 }
+DEFAULT_TIMEOUT = 10  # seconds
 
 SUBSCRIBER = "subscriber"
 

--- a/wampy/errors.py
+++ b/wampy/errors.py
@@ -22,3 +22,7 @@ class WebsocktProtocolError(Exception):
 
 class WampyError(Exception):
     pass
+
+
+class WampyTimeOutError(Exception):
+    pass

--- a/wampy/messages/__init__.py
+++ b/wampy/messages/__init__.py
@@ -5,6 +5,7 @@
 from . abort import Abort
 from . authenticate import Authenticate
 from . call import Call
+from . cancel import Cancel
 from . challenge import Challenge
 from . error import Error
 from . event import Event
@@ -41,6 +42,7 @@ MESSAGE_TYPE_MAP = {
     33: Subscribed,
     36: Event,
     48: Call,
+    49: Cancel,
     50: Result,
     64: Register,
     65: Registered,

--- a/wampy/messages/cancel.py
+++ b/wampy/messages/cancel.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+class Cancel(object):
+    """ When a Caller wishes to cancel a remote procedure, it sends a "CANCEL"
+    message to the Dealer.
+
+    Message is of the format
+    ``[CANCEL, CALL.Request|id, Options|dict]``, e.g. ::
+
+        [
+            CANCEL, 10001, {},
+        ]
+
+    "Request" is the ID used to make the Call being cancelled.
+
+    "Options" is a dictionary that allows to provide additional
+    cancellation request details in a extensible way.
+
+    """
+    WAMP_CODE = 49
+    name = "cancel"
+
+    def __init__(self, request_id, options=None):
+        super(Cancel, self).__init__()
+
+        self.request_id = request_id
+        self.options = options or {}
+
+    @property
+    def message(self):
+        return [
+            self.WAMP_CODE, self.request_id, self.options,
+        ]

--- a/wampy/messages/hello.py
+++ b/wampy/messages/hello.py
@@ -6,11 +6,20 @@
 class Hello(object):
     """ Send a HELLO message to the Router.
 
+    By default the *wampy* Client announces support for all four Client
+    Roles: Subscriber, Publisher, Callee and Caller.
+
     Message is of the format ``[HELLO, Realm|uri, Details|dict]``, e.g. ::
 
         [
             HELLO, "realm", {
-                "roles": {"subscriber": {}, "publisher": {}},
+                "roles": {
+                    "subscriber": {
+                        'features': {...},
+                    },
+                    "publisher": {...},
+                    ...
+                },
                 "authmethods": ["wampcra"],
                 "authid": "peter"
             }
@@ -20,14 +29,14 @@ class Hello(object):
     WAMP_CODE = 1
     name = "hello"
 
-    def __init__(self, realm, roles):
+    def __init__(self, realm, details):
         super(Hello, self).__init__()
 
         self.realm = realm
-        self.roles = roles
+        self.details = details
 
     @property
     def message(self):
         return [
-            self.WAMP_CODE, self.realm, self.roles
+            self.WAMP_CODE, self.realm, self.details
         ]

--- a/wampy/messages/result.py
+++ b/wampy/messages/result.py
@@ -34,6 +34,9 @@ class Result(object):
         self.yield_args = yield_args
         self.yield_kwargs = yield_kwargs
 
+    def __str__(self):
+        return str(self.message)
+
     @property
     def message(self):
         return [

--- a/wampy/peers/clients.py
+++ b/wampy/peers/clients.py
@@ -90,8 +90,8 @@ class Client(object):
 
         # the ``realm`` is the administrive domain to route messages over.
         self.realm = realm
-        # `roles` was a mistake and Roles are contained within a `details`
-        # dict which has been added below. `roles` will be deprecated.
+        # the ``roles`` define what Roles (features) the Client can act,
+        # but also configure behaviour such as auth
         self.roles = roles
         # a Session is a transient conversation between two Peers - a Client
         # and a Router. Here we model the Peer we are going to connect to.

--- a/wampy/peers/clients.py
+++ b/wampy/peers/clients.py
@@ -57,7 +57,7 @@ class Client(object):
                 Defaults to ``realm1``.
             roles : dictionary
                 Description of the Roles implemented by the ``Client``.
-                Defaults to ``wampy.constants.DEFAULT_DETAILS``.
+                Defaults to ``wampy.constants.DEFAULT_ROLES``.
             message_handler : instance
                 An instance of ``wampy.message_handler.MessageHandler``, or
                 a subclass of. This controls the conversation between the

--- a/wampy/peers/clients.py
+++ b/wampy/peers/clients.py
@@ -68,7 +68,7 @@ class Client(object):
             call_timeout : integer
                 A Caller might want to issue a call and provide a timeout after
                 which the call will finish.
-                The value should be in milli seconds.
+                The value should be in seconds.
             router : instance
                 An alternative way to connect to a Router rather than ``url``.
                 An instance of a Router Peer, e.g.

--- a/wampy/peers/clients.py
+++ b/wampy/peers/clients.py
@@ -101,19 +101,7 @@ class Client(object):
         self.message_handler = message_handler or MessageHandler()
         # generally ``name`` is used for debugging and logging only
         self.name = name or self.__class__.__name__
-
-        if not isinstance(call_timeout, int):
-            raise WampyError(
-                'Call Timeout must be an integer and in milli seconds'
-            )
-
-        # WAMP Call Message requires milliseconds...
         self.call_timeout = call_timeout
-        # ..whilst gevent and eventet prefer seconds. Whilst we wait for #299
-        # on Crossbar, wampy relies on eventlet/gevent timeouts. This is far
-        # from ideal, as the Dealer can still be processing the response for
-        # us and we just go away :(
-        self.call_timeout_seconds = round(call_timeout / 1000)
 
         # this conversation is over a transport. WAMP messages are transmitted
         # as WebSocket messages by default (well, actually... that's because no

--- a/wampy/roles/caller.py
+++ b/wampy/roles/caller.py
@@ -62,7 +62,6 @@ class RpcProxy:
             options = {
                 'timeout': self.client.call_timeout,
             }
-
             message = Call(
                 procedure=name, options=options, args=args, kwargs=kwargs,
             )

--- a/wampy/roles/caller.py
+++ b/wampy/roles/caller.py
@@ -63,8 +63,9 @@ class RpcProxy:
             # https://github.com/crossbario/crossbar/issues/299
             # is addressed, but we pass in the value regardless, waiting
             # for the feature on CrossBar.
+            # WAMP Call Message requires milliseconds...
             options = {
-                'timeout': self.client.call_timeout,
+                'timeout': int(self.client.call_timeout * 1000),
             }
             message = Call(
                 procedure=name, options=options, args=args, kwargs=kwargs,

--- a/wampy/roles/caller.py
+++ b/wampy/roles/caller.py
@@ -59,6 +59,10 @@ class RpcProxy:
     def __getattr__(self, name):
 
         def wrapper(*args, **kwargs):
+            # timeout is currently handled by wampy whilst
+            # https://github.com/crossbario/crossbar/issues/299
+            # is addressed, but we pass in the value regardless, waiting
+            # for the feature on CrossBar.
             options = {
                 'timeout': self.client.call_timeout,
             }

--- a/wampy/roles/caller.py
+++ b/wampy/roles/caller.py
@@ -59,7 +59,13 @@ class RpcProxy:
     def __getattr__(self, name):
 
         def wrapper(*args, **kwargs):
-            message = Call(procedure=name, args=args, kwargs=kwargs)
+            options = {
+                'timeout': self.client.call_timeout,
+            }
+
+            message = Call(
+                procedure=name, options=options, args=args, kwargs=kwargs,
+            )
             response = self.client.make_rpc(message)
 
             wamp_code = response.WAMP_CODE

--- a/wampy/session.py
+++ b/wampy/session.py
@@ -75,8 +75,8 @@ class Session(object):
         return self.router.port
 
     @property
-    def roles(self):
-        return self.client.roles
+    def details(self):
+        return self.client.details
 
     @property
     def realm(self):
@@ -119,7 +119,12 @@ class Session(object):
         return message
 
     def _say_hello(self):
-        message = Hello(self.realm, self.roles)
+        details = self.client.roles
+        for role, features in details['roles'].items():
+            features.setdefault('features', {})
+            features['features'].setdefault('call_timeout', True)
+
+        message = Hello(realm=self.realm, details=details)
         self.send_message(message)
         response = self.recv_message()
         return response

--- a/wampy/session.py
+++ b/wampy/session.py
@@ -83,6 +83,10 @@ class Session(object):
         return self.client.realm
 
     @property
+    def call_timeout(self):
+        return self.client.call_timeout
+
+    @property
     def id(self):
         return self.session_id
 
@@ -110,8 +114,8 @@ class Session(object):
 
         self.connection.send(message)
 
-    def recv_message(self, timeout=5):
-        message = async_adapter.receive_message(timeout=timeout)
+    def recv_message(self):
+        message = async_adapter.receive_message(timeout=self.call_timeout)
         logger.debug(
             'received message: "%s" for client "%s"',
             message.name, self.client.name,
@@ -139,7 +143,7 @@ class Session(object):
             logger.warning("GOODBYE failed!: %s", exc)
         else:
             try:
-                message = self.recv_message(timeout=2)
+                message = self.recv_message()
                 if message.WAMP_CODE != Goodbye.WAMP_CODE:
                     raise WampProtocolError(
                         "Unexpected response from GOODBYE message: {}".format(

--- a/wampy/session.py
+++ b/wampy/session.py
@@ -106,9 +106,9 @@ class Session(object):
 
         self.connection.send(message)
 
-    def recv_message(self):
+    def recv_message(self, timeout=None):
         message = async_adapter.receive_message(
-            timeout=self.client.call_timeout,
+            timeout=timeout or self.client.call_timeout,
         )
         logger.debug(
             'received message: "%s" for client "%s"',
@@ -134,10 +134,12 @@ class Session(object):
         except Exception as exc:
             # we can't be sure what the Exception is here because it will
             # be from the Router implementation
-            logger.warning("GOODBYE failed!: %s", exc)
+            logger.exception("GOODBYE failed!: %s", exc)
         else:
             try:
-                message = self.recv_message()
+                # TODO: appears to be a bug as we have never been receiving
+                # the echoed GOODBYE
+                message = self.recv_message(timeout=1)
                 if message.WAMP_CODE != Goodbye.WAMP_CODE:
                     raise WampProtocolError(
                         "Unexpected response from GOODBYE message: {}".format(

--- a/wampy/session.py
+++ b/wampy/session.py
@@ -75,10 +75,6 @@ class Session(object):
         return self.router.port
 
     @property
-    def details(self):
-        return self.client.details
-
-    @property
     def realm(self):
         return self.client.realm
 
@@ -112,7 +108,7 @@ class Session(object):
 
     def recv_message(self):
         message = async_adapter.receive_message(
-            timeout=self.client.call_timeout_seconds
+            timeout=self.client.call_timeout,
         )
         logger.debug(
             'received message: "%s" for client "%s"',

--- a/wampy/testing/configs/crossbar.json
+++ b/wampy/testing/configs/crossbar.json
@@ -27,7 +27,33 @@
                               },
                               "cache": true
                           }
-                      ]
+                      ],
+                      "features": {
+                          "call_timeout": true
+                      }
+                  }, 
+                  {
+                     "name": "dealer",
+                     "permissions": [
+                          {
+                              "uri": "",
+                              "match": "prefix",
+                              "allow": {
+                                  "call": true,
+                                  "register": true,
+                                  "publish": true,
+                                  "subscribe": true
+                              },
+                              "disclose": {
+                                  "caller": false,
+                                  "publisher": false
+                              },
+                              "cache": true
+                          }
+                      ],
+                      "features": {
+                          "call_timeout": true
+                      }
                   }
                ]
             }

--- a/wampy/transports/websocket/frames.py
+++ b/wampy/transports/websocket/frames.py
@@ -100,14 +100,16 @@ class Frame(object):
 
     @property
     def payload(self):
-        """ Return the ``frame-payload-data`` from the raw bytes.
-        """
-        if self.payload_length_indicator < 126:
-            payload_str = self.raw_bytes[2:].decode('utf-8')
-        elif self.payload_length_indicator == 126:
-            payload_str = self.raw_bytes[4:].decode('utf-8')
-        else:
-            payload_str = self.raw_bytes[6:].decode('utf-8')
+        try:
+            if self.payload_length_indicator < 126:
+                payload_str = self.raw_bytes[2:].decode('utf-8')
+            elif self.payload_length_indicator == 126:
+                payload_str = self.raw_bytes[4:].decode('utf-8')
+            else:
+                payload_str = self.raw_bytes[6:].decode('utf-8')
+        except UnicodeDecodeError:
+            logger.error('cannot decode %s', self.raw_bytes)
+            raise
 
         return payload_str
 


### PR DESCRIPTION
Far from ideal. Initially, this PR was to implement WAMP call timeout - but Crossbar does not support that "advanced" feature yet.

So for a quick fix I pass this value through to the async backend timeout value where we simply stop listening for a response and return.

the problem with this is that the Broker/Dealer is still processing the request and sends it back to wampy anyway. i try and stop this by sending a Cancel message, but a race condition exists for short timeout values... but this is not an immediate problem.

Looking at the version of Crossbar that wampy uses i was shocked... so that has received a massive bump in this PR, which then forced bumps of six and other dependencies. I could not bump it any further as support for Mac OS on Crossbar actually _breaks_ after this version - see https://github.com/crossbario/crossbar/issues/1333

