### PR TITLE
Added Python 3.9 compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[tool:pytest]
-
-filterwarnings = 
-	# Python 2.7 must be supported and these warnings are annoying
-	ignore:tostring:DeprecationWarning
-	ignore:fromstring:DeprecationWarning
-	ignore:encodestring:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='WAMP RPC',
     packages=find_packages(),

--- a/wampy/transports/websocket/connection.py
+++ b/wampy/transports/websocket/connection.py
@@ -7,7 +7,7 @@ import sched
 import socket
 import ssl
 import uuid
-from base64 import encodestring
+from base64 import encodebytes
 from socket import error as socket_error
 from time import time
 
@@ -42,7 +42,7 @@ class WebSocket(Transport, ParseUrlMixin):
 
         self.parse_url()
         self.websocket_location = self.resource
-        self.key = encodestring(uuid.uuid4().bytes).decode('utf-8').strip()
+        self.key = encodebytes(uuid.uuid4().bytes).decode('utf-8').strip()
         self.socket = None
         self.connected = False
 

--- a/wampy/transports/websocket/frames.py
+++ b/wampy/transports/websocket/frames.py
@@ -263,7 +263,7 @@ class FrameFactory(object):
         for i in range(len(_d)):
             _d[i] ^= _m[i % 4]
 
-        return _d.tostring()
+        return _d.tobytes()
 
     @classmethod
     def generate_bytes(cls, payload, fin_bit, opcode, mask_payload):


### PR DESCRIPTION
Just changed the deprecated calls (encodestring, tostring) to their Python 3 equivalent and removed the filterwarnings.